### PR TITLE
Initialize Node.js backend server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.env
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+dist
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# rag-project-management
+# RAG Project Management Backend
+
+This repository contains a minimal Node.js backend server for the RAG Project Management workspace. The server is built with [Express](https://expressjs.com/) and exposes a couple of basic routes to verify that the service is running.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) (version 18 or newer is recommended)
+- [npm](https://www.npmjs.com/) or [pnpm](https://pnpm.io/) for package management
+
+## Getting started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the development server with automatic reloads:
+
+   ```bash
+   npm run dev
+   ```
+
+   This uses `nodemon` to watch the source files and restart the server on changes.
+
+3. Or run the production server:
+
+   ```bash
+   npm start
+   ```
+
+## Available endpoints
+
+- `GET /` – returns a welcome message.
+- `GET /health` – returns a simple health check payload.
+
+Both endpoints respond with JSON.
+
+## Environment variables
+
+- `PORT` – port number the server should listen on. Defaults to `3000` if not provided.
+
+## Project structure
+
+```
+.
+├── package.json
+├── README.md
+└── src
+    └── server.js
+```
+
+Feel free to expand this starter project to include additional routes, middleware, and integrations required for your RAG project management needs.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "rag-project-management-server",
+  "version": "0.1.0",
+  "description": "Simple Node.js backend server for the RAG project management workspace.",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "nodemon src/server.js"
+  },
+  "keywords": [
+    "node",
+    "express",
+    "server"
+  ],
+  "author": "",
+  "license": "MIT",
+  "type": "module",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3"
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(cors());
+app.use(express.json());
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Welcome to the RAG Project Management backend service.' });
+});
+
+app.use((req, res) => {
+  res.status(404).json({ error: 'Not found' });
+});
+
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+app.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- set up a Node.js project configuration with dependencies and scripts for running the backend server
- implement a simple Express server with basic health and root endpoints and document usage in the README

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e0cb165bcc832d81fe16e1f5def826